### PR TITLE
Modify deploy.yml to use GH Personal Authentication Token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -29,11 +30,11 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           # original file used GITHUB_TOKEN
-          # github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Changed above line to use SSH Private Key instead 
           # per https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-ssh-private-key-deploy_key
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration for deploying to GitHub Pages. The changes involve adding a new event trigger and modifying the authentication method for deployment.

Updates to GitHub Actions workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R4): Added `workflow_dispatch` event trigger to allow manual triggering of the workflow.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L32-R37): Updated the authentication method by uncommenting the `github_token` line and commenting out the `deploy_key` line to use `GITHUB_TOKEN` instead of an SSH private key.